### PR TITLE
Make mv move file to folder too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+releases

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -148,6 +148,15 @@ func (r *Repository) Move(ctx context.Context, from, to string) (<-chan *Note, <
 			}
 			success <- true
 		}()
+		lstat, err := os.Lstat(to)
+		if err != nil && !os.IsNotExist(err) {
+			errs <- err
+			return
+		}
+		if !os.IsNotExist(err) && lstat.IsDir() {
+			_, file := filepath.Split(from)
+			to = filepath.Join(to, file)
+		}
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
At the moment file can be moved by specifying `from` and `to` path, for example:

```bash
noteo mv from.md to.md
```

It would be nice to have a functionality for moving a file to a different dir without specyfing a target file name:

```bash
noteo mv from.md to-dir
```

The last command should move `from.md` to file `to-dir/from.md`