### PR TITLE
Add modified/created columns to ls command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ noteo add My fantastic idea
   my-fantastic-idea.md created
 
 $ noteo ls
-  FILE                                BEGINNING            MODIFIED              TAGS
+  FILE                                BEGINNING            MODIFIEDAGO           TAGS
   my-fantastic-idea.md                My fantastic idea    About a minute ago
 
 $ noteo tag set -n idea my-fantastic-idea.md
@@ -48,14 +48,14 @@ $ noteo mv my-fantastic-idea.md some-project/my-fantastic-idea.md
   File moved
 
 $ noteo ls --tag idea
-  FILE                                BEGINNING            MODIFIED              TAGS
+  FILE                                BEGINNING            MODIFIEDAGO           TAGS
   some-project/my-fantastic-idea.md   My fantastic idea    About a minute ago    idea
 
 $ noteo tag set -n deadline:2020-08-30 some-project/my-fantastic-idea.md
 some-project/my-fantastic-idea.md updated
 
 $ noteo ls --tag-after deadline:2020-08-01
-  FILE                                BEGINNING            MODIFIED          TAGS                 
+  FILE                                BEGINNING            MODIFIEDAGO       TAGS                 
   some-project/my-fantastic-idea.md   My fantastic idea    21 seconds ago    idea deadline:2020-08-30
 ```
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -76,7 +76,7 @@ func ls() *cobra.Command {
   noteo ls -o table=file,tags`,
 	}
 	ls.Flags().BoolVarP(&c.quietMode, "quiet", "q", false, "")
-	ls.Flags().StringVarP(&c.outputFormat, "output", "o", "table=file,beginning,modified,tags", "")
+	ls.Flags().StringVarP(&c.outputFormat, "output", "o", "table=file,beginning,modifiedago,tags", "")
 	// filtering
 	ls.Flags().StringArrayVarP(&c.tagFilter, "tag", "t", nil, "")
 	ls.Flags().StringArrayVar(&c.notagFilter, "no-tag", nil, "")
@@ -135,7 +135,7 @@ Sorting and limiting flags:
 Other flags:
   -h, --help                        help for ls
   -o, --output string               Specify output format: table using given columns, wide, json or yaml
-                                    (default "table=file,beginning,modified,tags")
+                                    (default "table=file,beginning,modifiedago,tags")
   -q, --quiet                       Show only file names{{if .HasAvailableInheritedFlags}}
 Global Flags:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
@@ -294,7 +294,7 @@ func (c *lsCommand) formatter() (formatter, error) {
 	case c.quietMode:
 		out = quiet.Formatter{}
 	case outputFormat == "wide":
-		out, err = table.NewFormatter([]string{"file", "beginning", "modified", "created", "tags"})
+		out, err = table.NewFormatter([]string{"file", "beginning", "modifiedago", "createdago", "tags"})
 	case strings.HasPrefix(outputFormat, "table="):
 		columns := strings.Split(strings.TrimPrefix(outputFormat, "table="), ",")
 		out, err = table.NewFormatter(columns)

--- a/output/table/table.go
+++ b/output/table/table.go
@@ -23,7 +23,11 @@ func NewFormatter(columns []string) (*Formatter, error) {
 	for _, c := range columns {
 		c = strings.ToUpper(c)
 		if _, ok := mapping[c]; !ok {
-			return nil, fmt.Errorf("unsupported output column: %s", c)
+			var allColumns []string
+			for k := range mapping {
+				allColumns = append(allColumns, k)
+			}
+			return nil, fmt.Errorf("unsupported output column: %s. Possible values are: %s", c, strings.Join(allColumns, ","))
 		}
 		cols = append(cols, c)
 	}

--- a/output/table/table.go
+++ b/output/table/table.go
@@ -11,11 +11,11 @@ import (
 )
 
 var mapping = map[string]column{
-	"FILE":      fileColumn{},
-	"BEGINNING": beginningColumn{},
-	"MODIFIED":  modifiedColumn{},
-	"CREATED":   createdColumn{},
-	"TAGS":      tagsColumn{},
+	"FILE":        fileColumn{},
+	"BEGINNING":   beginningColumn{},
+	"MODIFIEDAGO": modifiedAgoColumn{},
+	"CREATEDAGO":  createdAgoColumn{},
+	"TAGS":        tagsColumn{},
 }
 
 func NewFormatter(columns []string) (*Formatter, error) {
@@ -105,24 +105,24 @@ func (s beginningColumn) cell(note notes.Note) string {
 	return format(beginning(text), 34)
 }
 
-type modifiedColumn struct{}
+type modifiedAgoColumn struct{}
 
-func (m modifiedColumn) header() string {
-	return format("MODIFIED", 18)
+func (m modifiedAgoColumn) header() string {
+	return format("MODIFIEDAGO", 18)
 }
 
-func (m modifiedColumn) cell(note notes.Note) string {
+func (m modifiedAgoColumn) cell(note notes.Note) string {
 	modified := date.Format(note.Modified())
 	return format(modified, 18)
 }
 
-type createdColumn struct{}
+type createdAgoColumn struct{}
 
-func (c createdColumn) header() string {
-	return format("CREATED", 18)
+func (c createdAgoColumn) header() string {
+	return format("CREATEDAGO", 18)
 }
 
-func (c createdColumn) cell(note notes.Note) string {
+func (c createdAgoColumn) cell(note notes.Note) string {
 	created, err := note.Created()
 	if err != nil {
 		errString := err.Error()


### PR DESCRIPTION
This columns should have always unix date format. Existing columns with these names should be renamed to modifiedago/createdago. 