### PR TITLE
Make editor configurable

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jacekolszak/noteo/config"
 	"github.com/jacekolszak/noteo/repository"
 	"github.com/spf13/cobra"
 )
-
-var editor = "vim +"
 
 var add = &cobra.Command{
 	Use:   "add [TEXT]",
@@ -32,6 +31,11 @@ var add = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		repoConfig, err := repo.Config()
+		if err != nil {
+			return err
+		}
+		cfg := config.New(repoConfig)
 		var text string
 		if len(cmd.Flags().Args()) == 0 {
 			template := newFileTemplate(time.Now()) + "\n"
@@ -39,7 +43,7 @@ var add = &cobra.Command{
 			if err := ioutil.WriteFile(tmpFile, []byte(template), 0664); err != nil {
 				return err
 			}
-			text, err = textFromEditor(tmpFile)
+			text, err = textFromEditor(tmpFile, cfg.EditorCommand())
 			if err != nil {
 				return err
 			}
@@ -62,8 +66,8 @@ var add = &cobra.Command{
 	},
 }
 
-func textFromEditor(file string) (string, error) {
-	editorNameWithArgs := strings.Split(editor, " ")
+func textFromEditor(file, editorCommand string) (string, error) {
+	editorNameWithArgs := strings.Split(editorCommand, " ")
 	name := editorNameWithArgs[0]
 	args := append(editorNameWithArgs[1:], file)
 	cmd := exec.Command(name, args...)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,11 +11,11 @@ var initialize = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize a Noteo repository",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := repository.Init(".")
+		cfgFile, err := repository.Init(".")
 		if err != nil {
 			return err
 		}
-		fmt.Println("repo initialized")
+		fmt.Printf("Repository initialized. Configuration file saved at %s\n", cfgFile)
 		return nil
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,35 @@
+// Package config provides configuration from merging environment and repository config
+package config
+
+import (
+	"os"
+	"runtime"
+)
+
+type RepoConfig interface {
+	EditorCommand() string
+}
+
+type Config struct {
+	repoConfig RepoConfig
+}
+
+func New(config RepoConfig) *Config {
+	return &Config{repoConfig: config}
+}
+
+func (c *Config) EditorCommand() string {
+	if c.repoConfig.EditorCommand() != "" {
+		return c.repoConfig.EditorCommand()
+	}
+	if visual := os.Getenv("VISUAL"); visual != "" {
+		return visual
+	}
+	if editor := os.Getenv("EDITOR"); editor != "" {
+		return editor
+	}
+	if runtime.GOOS == "windows" {
+		return "notepad"
+	}
+	return "vim +"
+}

--- a/repository/config.go
+++ b/repository/config.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+func parse(file string) (*Config, error) {
+	c := &Config{}
+	bytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	if err = yaml.Unmarshal(bytes, c); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type Config struct {
+	Editor string `yaml:"editor"`
+}
+
+func (r *Config) EditorCommand() string {
+	return r.Editor
+}

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -257,7 +257,7 @@ func assertSuccess(t *testing.T, ctx context.Context, notes <-chan *repository.N
 func repo(t *testing.T) (dir string, repo *repository.Repository) {
 	dir, err := ioutil.TempDir("", "noteo-test")
 	require.NoError(t, err)
-	err = repository.Init(dir)
+	_, err = repository.Init(dir)
 	require.NoError(t, err)
 	repo, err = repository.ForWorkDir(dir)
 	require.NoError(t, err)


### PR DESCRIPTION
* [x] add editor to repository config file `.noteo.yml`
* [x] use $VISUAL or $EDITOR
* [x] use vim+ on Linux and Mac, notepad on Windows