### PR TITLE
Rename module to github.com/elgopher/noteo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Noteo is a command line note-taking assistant which can be helpful in all 3 stag
 
 ## Installation
 
-Download the [release archive](https://github.com/jacekolszak/noteo/releases) and extract the binary to your `bin` folder.
+Download the [release archive](https://github.com/elgopher/noteo/releases) and extract the binary to your `bin` folder.
 
 If your OS/arch is not available you can try to build it manually using [Go](https://golang.org/):
 
 ```bash
-go get -u github.com/jacekolszak/noteo
+go get -u github.com/elgopher/noteo
 ```
 
 ## Demo

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/elgopher/noteo/config"
 	"github.com/google/uuid"
-	"github.com/jacekolszak/noteo/config"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jacekolszak/noteo/note"
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/repository"
+	"github.com/elgopher/noteo/note"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/repository"
 )
 
 func repo(commandArgs []string) (*repository.Repository, error) {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/jacekolszak/noteo/repository"
+	"github.com/elgopher/noteo/repository"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -7,12 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/output/jayson"
-	"github.com/jacekolszak/noteo/output/quiet"
-	"github.com/jacekolszak/noteo/output/table"
-	"github.com/jacekolszak/noteo/output/yml"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/output/jayson"
+	"github.com/elgopher/noteo/output/quiet"
+	"github.com/elgopher/noteo/output/table"
+	"github.com/elgopher/noteo/output/yml"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/tagrm.go
+++ b/cmd/tagrm.go
@@ -4,7 +4,7 @@ import (
 	"bufio"
 	"fmt"
 
-	"github.com/jacekolszak/noteo/repository"
+	"github.com/elgopher/noteo/repository"
 	"github.com/spf13/cobra"
 )
 

--- a/date/date_test.go
+++ b/date/date_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
+	"github.com/elgopher/noteo/date"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jacekolszak/noteo
+module github.com/elgopher/noteo
 
 go 1.14
 

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/jacekolszak/noteo/cmd"
+	"github.com/elgopher/noteo/cmd"
 )
 
 func main() {

--- a/note/frontmatter.go
+++ b/note/frontmatter.go
@@ -7,8 +7,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/tag"
 	"gopkg.in/yaml.v2"
 )
 

--- a/note/note.go
+++ b/note/note.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/tag"
 )
 
 type Note struct {

--- a/note/note_test.go
+++ b/note/note_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/note"
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/note"
+	"github.com/elgopher/noteo/tag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/note/original.go
+++ b/note/original.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/jacekolszak/noteo/parser"
+	"github.com/elgopher/noteo/parser"
 )
 
 type originalContent struct {

--- a/notes/filter.go
+++ b/notes/filter.go
@@ -6,8 +6,8 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/tag"
 )
 
 func Filter(ctx context.Context, notes <-chan Note, predicates ...Predicate) (note <-chan Note, errors <-chan error) {

--- a/notes/filter_test.go
+++ b/notes/filter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/notes"
+	"github.com/elgopher/noteo/notes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/notes/notes.go
+++ b/notes/notes.go
@@ -3,7 +3,7 @@ package notes
 import (
 	"time"
 
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/tag"
 )
 
 type Note interface {

--- a/notes/top_test.go
+++ b/notes/top_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/tag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/output/jayson/json.go
+++ b/output/jayson/json.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/output"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/output"
 )
 
 type Formatter struct{}

--- a/output/output.go
+++ b/output/output.go
@@ -1,6 +1,6 @@
 package output
 
-import "github.com/jacekolszak/noteo/notes"
+import "github.com/elgopher/noteo/notes"
 
 func StringTags(note notes.Note) ([]string, error) {
 	var ret []string

--- a/output/quiet/quiet.go
+++ b/output/quiet/quiet.go
@@ -1,7 +1,7 @@
 package quiet
 
 import (
-	"github.com/jacekolszak/noteo/notes"
+	"github.com/elgopher/noteo/notes"
 )
 
 type Formatter struct {

--- a/output/table/table.go
+++ b/output/table/table.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/output"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/output"
 	"github.com/juju/ansiterm"
 	"golang.org/x/crypto/ssh/terminal"
 )

--- a/output/yml/yml.go
+++ b/output/yml/yml.go
@@ -3,8 +3,8 @@ package yml
 import (
 	"time"
 
-	"github.com/jacekolszak/noteo/notes"
-	"github.com/jacekolszak/noteo/output"
+	"github.com/elgopher/noteo/notes"
+	"github.com/elgopher/noteo/output"
 	"gopkg.in/yaml.v2"
 )
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jacekolszak/noteo/parser"
+	"github.com/elgopher/noteo/parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -12,10 +12,10 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/elgopher/noteo/note"
+	"github.com/elgopher/noteo/parser"
+	"github.com/elgopher/noteo/tag"
 	"github.com/google/uuid"
-	"github.com/jacekolszak/noteo/note"
-	"github.com/jacekolszak/noteo/parser"
-	"github.com/jacekolszak/noteo/tag"
 	godiacritics "gopkg.in/Regis24GmbH/go-diacritics.v2"
 )
 

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/note"
-	"github.com/jacekolszak/noteo/repository"
+	"github.com/elgopher/noteo/note"
+	"github.com/elgopher/noteo/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/tag/tag.go
+++ b/tag/tag.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
+	"github.com/elgopher/noteo/date"
 )
 
 var validName = regexp.MustCompile(`^\S+$`)

--- a/tag/tag_test.go
+++ b/tag/tag_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jacekolszak/noteo/date"
-	"github.com/jacekolszak/noteo/tag"
+	"github.com/elgopher/noteo/date"
+	"github.com/elgopher/noteo/tag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
Recently Github user name jacekolszak was changed to elgopher. Change the Go module accordingly. From `github.com/jacekolszak/noteo` to `github.com/elgopher/noteo`